### PR TITLE
Fixed generation of the license badge in README

### DIFF
--- a/src/bundle/Resources/skeleton/bundle/README.md.html.twig
+++ b/src/bundle/Resources/skeleton/bundle/README.md.html.twig
@@ -2,7 +2,7 @@
 
 [![Downloads](https://img.shields.io/packagist/dt/edgar/ez-{{ bundle_short_lower }}-bundle.svg?style=flat-square)](https://packagist.org/packages/{{ vendor_name_lower }}/ez-{{ bundle_short_lower }}-bundle)
 [![Latest release](https://img.shields.io/github/release/{{ vendor_name }}/{{ bundle }}.svg?style=flat-square)](https://github.com/{{ vendor_name }}/{{ bundle }}/releases)
-[![License](https://img.shields.io/packagist/l/{{ vendor_name_lower }}/ez-{{ bundle_short_lower }}-bundle.svg?style=flat-square)](LICENSE.html.twig)
+[![License](https://img.shields.io/packagist/l/{{ vendor_name_lower }}/ez-{{ bundle_short_lower }}-bundle.svg?style=flat-square)](LICENSE)
 
 ## Description
 


### PR DESCRIPTION
License badge in the generated README file should point to `LICENSE` instead of `LICENSE.html.twig` :wink: 